### PR TITLE
feat: add Radix UI theme

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import './globals.css';
+import '@radix-ui/themes/styles.css';
 import { Providers } from '@/src/providers/ReduxProvider';
 
 export const metadata: Metadata = {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,10 +1,16 @@
+import { Button } from '@/src/components/ui/Button';
+
 export default function HomePage() {
   return (
     <main className="container">
       <h1>ברוכים הבאים לבלוג</h1>
       <p className="muted">שלד ראשוני – Next.js + Redux + נתיב עורך.</p>
       <ul>
-        <li><a href="/editor">עבור לעורך</a></li>
+        <li>
+          <Button asChild>
+            <a href="/editor">עבור לעורך</a>
+          </Button>
+        </li>
       </ul>
     </main>
   );

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "next": "14.2.5",
     "react": "18.3.1",
     "react-dom": "18.3.1",
+    "@radix-ui/themes": "^2.0.0",
     "@reduxjs/toolkit": "2.2.3",
     "react-redux": "9.1.2"
   },

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,0 +1,8 @@
+"use client";
+import { Button as RadixButton, type ButtonProps } from '@radix-ui/themes';
+
+export function Button(props: ButtonProps) {
+  return <RadixButton {...props} />;
+}
+
+export default Button;

--- a/src/providers/ReduxProvider.tsx
+++ b/src/providers/ReduxProvider.tsx
@@ -1,9 +1,14 @@
 "use client";
 import { Provider } from 'react-redux';
 import { store } from '@/src/store/store';
+import { Theme } from '@radix-ui/themes';
 
 export function Providers({ children }: { children: React.ReactNode }) {
-  return <Provider store={store}>{children}</Provider>;
+  return (
+    <Provider store={store}>
+      <Theme>{children}</Theme>
+    </Provider>
+  );
 }
 
 export default Providers;


### PR DESCRIPTION
## Summary
- integrate Radix UI theme provider into app layout
- add example Button component using Radix UI
- wire Radix styles into application root and home page

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: No files matching the pattern "." were found)


------
https://chatgpt.com/codex/tasks/task_e_68bb4db4ea30832c88ca0063c23825a2