### PR TITLE
Add blog listing, post page and publish redirect

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -1,0 +1,31 @@
+interface Post {
+  id: number;
+  title: string;
+  body: string;
+}
+
+async function getPost(id: string): Promise<Post> {
+  const res = await fetch(`https://jsonplaceholder.typicode.com/posts/${id}`);
+  return res.json();
+}
+
+function markdownToHtml(md: string) {
+  return md
+    .replace(/^### (.*$)/gim, '<h3>$1</h3>')
+    .replace(/^## (.*$)/gim, '<h2>$1</h2>')
+    .replace(/^# (.*$)/gim, '<h1>$1</h1>')
+    .replace(/\*\*(.*?)\*\*/gim, '<strong>$1</strong>')
+    .replace(/\*(.*?)\*/gim, '<em>$1</em>')
+    .replace(/\n/gim, '<br />');
+}
+
+export default async function BlogPostPage({ params }: { params: { slug: string } }) {
+  const post = await getPost(params.slug);
+  return (
+    <main className="container">
+      <h1>{post.title}</h1>
+      <article dangerouslySetInnerHTML={{ __html: markdownToHtml(post.body) }} />
+    </main>
+  );
+}
+

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,0 +1,33 @@
+import Link from 'next/link';
+
+interface Post {
+  id: number;
+  title: string;
+  body: string;
+}
+
+async function getPosts(): Promise<Post[]> {
+  const res = await fetch('https://jsonplaceholder.typicode.com/posts');
+  return res.json();
+}
+
+export default async function BlogPage() {
+  const posts = await getPosts();
+
+  return (
+    <main className="container">
+      <h1>הבלוג</h1>
+      <ul style={{ padding: 0, listStyle: 'none' }}>
+        {posts.slice(0, 10).map((post) => (
+          <li key={post.id} className="card" style={{ marginBottom: 12 }}>
+            <h2 style={{ marginBottom: 4 }}>
+              <Link href={`/blog/${post.id}`}>{post.title}</Link>
+            </h2>
+            <p className="muted">{post.body.slice(0, 100)}...</p>
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}
+

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,6 +8,11 @@ export default function HomePage() {
       <ul>
         <li>
           <Button asChild>
+            <a href="/blog">צפה בבלוג</a>
+          </Button>
+        </li>
+        <li>
+          <Button asChild>
             <a href="/editor">עבור לעורך</a>
           </Button>
         </li>

--- a/src/components/editor/Sidebar.tsx
+++ b/src/components/editor/Sidebar.tsx
@@ -6,11 +6,24 @@ import { useState } from 'react';
 export default function Sidebar() {
   const dispatch = useAppDispatch();
   const meta = useAppSelector((s) => s.editor.meta);
+  const slug = useAppSelector((s) => s.editor.slug);
   const [tagInput, setTagInput] = useState('');
   const [catInput, setCatInput] = useState('');
 
   return (
     <div className="card" aria-label="מאפייני פוסט">
+      <nav style={{ marginBottom: 12 }}>
+        <ul style={{ listStyle: 'none', padding: 0, margin: 0, display: 'flex', flexDirection: 'column', gap: 4 }}>
+          <li>
+            <a href="/blog">כל הפוסטים</a>
+          </li>
+          {slug && (
+            <li>
+              <a href={`/blog/${slug}`}>הצג פוסט</a>
+            </li>
+          )}
+        </ul>
+      </nav>
       <h3 style={{ marginTop: 0 }}>מאפיינים</h3>
 
       <section style={{ marginBottom: 12 }}>

--- a/src/components/editor/Toolbar.tsx
+++ b/src/components/editor/Toolbar.tsx
@@ -1,10 +1,29 @@
 "use client";
 import { useAppDispatch, useAppSelector } from '@/src/store/hooks';
 import { reset, setStatus } from '@/src/store/slices/editorSlice';
+import { useRouter } from 'next/navigation';
 
 export default function Toolbar() {
   const dispatch = useAppDispatch();
-  const status = useAppSelector((s) => s.editor.status);
+  const editor = useAppSelector((s) => s.editor);
+  const status = editor.status;
+  const router = useRouter();
+
+  async function handlePublish() {
+    try {
+      const res = await fetch('https://jsonplaceholder.typicode.com/posts', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title: editor.title, body: editor.body, slug: editor.slug })
+      });
+      const data = await res.json();
+      dispatch(setStatus('published'));
+      router.push(`/blog/${data.id || editor.slug}`);
+    } catch (err) {
+      console.error(err);
+      alert('שגיאה בפרסום');
+    }
+  }
 
   return (
     <div className="toolbar">
@@ -14,7 +33,7 @@ export default function Toolbar() {
       <button onClick={() => dispatch(setStatus('in_review'))} aria-pressed={status === 'in_review'}>
         שלח לסקירה
       </button>
-      <button onClick={() => alert('פרסום – יוגדר בהמשך (CMS/Webhook)')}>פרסם</button>
+      <button onClick={handlePublish}>פרסם</button>
       <button onClick={() => dispatch(reset())}>איפוס</button>
       <span className="muted" style={{ marginInlineStart: 8 }}>
         מצב: <strong>{status}</strong>


### PR DESCRIPTION
## Summary
- add /blog index and dynamic post pages powered by JSONPlaceholder
- redirect editor publish to new post and link to blog from sidebar and home

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx eslint . --ext .js,.jsx,.ts,.tsx` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68bb5394fe60832c9fa5f81db6c44188