### PR TITLE
Add basic Vitest setup with editor action tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "test": "vitest run"
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.15",
@@ -33,6 +34,7 @@
     "eslint-config-next": "14.2.5",
     "postcss": "8.4.41",
     "tailwindcss": "3.4.9",
-    "typescript": "5.4.5"
+    "typescript": "5.4.5",
+    "vitest": "^0.34.6"
   }
 }

--- a/src/store/slices/editorSlice.test.ts
+++ b/src/store/slices/editorSlice.test.ts
@@ -1,0 +1,22 @@
+import reducer, { setTitle, addTag, reset } from './editorSlice';
+
+const getInitialState = () => reducer(undefined, { type: 'init' });
+
+describe('editorSlice actions', () => {
+  it('setTitle updates the title', () => {
+    const state = reducer(getInitialState(), setTitle('My Title'));
+    expect(state.title).toBe('My Title');
+  });
+
+  it('addTag adds a new tag', () => {
+    const state = reducer(getInitialState(), addTag('news'));
+    expect(state.meta.tags).toContain('news');
+  });
+
+  it('reset restores the initial state', () => {
+    let state = reducer(getInitialState(), setTitle('Temp'));
+    state = reducer(state, addTag('temp'));
+    const resetState = reducer(state, reset());
+    expect(resetState).toEqual(getInitialState());
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+import { fileURLToPath } from 'url';
+
+export default defineConfig({
+  test: {
+    environment: 'node'
+  },
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./', import.meta.url))
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- configure Vitest and npm test script
- test editor slice actions: setTitle, addTag, reset

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bbc5badaac832c93f1514cdcb4962e