### PR TITLE
Improve draft autosave storage checks

### DIFF
--- a/src/components/editor/EditorShell.tsx
+++ b/src/components/editor/EditorShell.tsx
@@ -13,6 +13,36 @@ export default function EditorShell() {
   const doc = useAppSelector((s) => s.editor);
   const debounceRef = useRef<NodeJS.Timeout | null>(null);
 
+  // Check for storage permissions on mount
+  useEffect(() => {
+    let cancelled = false;
+    async function ensureStoragePermission() {
+      try {
+        if (typeof navigator !== 'undefined' && navigator.storage?.persist) {
+          const persisted = await navigator.storage.persisted();
+          if (!persisted) {
+            const granted = await navigator.storage.persist();
+            if (!granted && !cancelled) {
+              alert(
+                'אי אפשר להבטיח שמירת טיוטות לאורך זמן; שקלו להעתיק את התוכן ידנית.'
+              );
+            }
+          }
+        }
+      } catch {
+        if (!cancelled) {
+          alert(
+            'בדיקת הרשאות האחסון נכשלה; שקלו להעתיק את התוכן ידנית.'
+          );
+        }
+      }
+    }
+    ensureStoragePermission();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   // Hydrate from localStorage on mount
   useEffect(() => {
     try {
@@ -31,11 +61,39 @@ export default function EditorShell() {
   useEffect(() => {
     if (debounceRef.current) clearTimeout(debounceRef.current);
     debounceRef.current = setTimeout(() => {
-      try {
-        const payload = { ...doc, lastSavedAt: Date.now() };
-        localStorage.setItem('editor-draft', JSON.stringify(payload));
-        dispatch(setLastSavedAt(payload.lastSavedAt));
-      } catch {}
+      (async () => {
+        try {
+          const payload = { ...doc, lastSavedAt: Date.now() };
+          const serialized = JSON.stringify(payload);
+          const size = new Blob([serialized]).size;
+          const max = 5 * 1024 * 1024; // ~5MB
+          if (size > max) {
+            alert('הטיוטה גדולה מדי ולא ניתן לשמור אותה בדפדפן.');
+            return;
+          }
+          if (
+            typeof navigator !== 'undefined' &&
+            navigator.storage?.estimate
+          ) {
+            const { quota, usage } = await navigator.storage.estimate();
+            if (
+              typeof quota === 'number' &&
+              typeof usage === 'number' &&
+              usage + size > quota
+            ) {
+              alert(
+                'אין מספיק מקום אחסון בדפדפן; שמרו עותק מקומי של התוכן.'
+              );
+              return;
+            }
+          }
+          localStorage.setItem('editor-draft', serialized);
+          dispatch(setLastSavedAt(payload.lastSavedAt));
+        } catch (err) {
+          console.error('failed to save draft', err);
+          alert('שגיאה בשמירת הטיוטה; שקלו להעתיק את התוכן ידנית.');
+        }
+      })();
     }, 800);
     return () => {
       if (debounceRef.current) clearTimeout(debounceRef.current);


### PR DESCRIPTION
## Summary
- handle missing storage permissions and alert user
- validate available storage and limit draft size when autosaving

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build` *(fails: Cannot find module 'tailwindcss')*

------
https://chatgpt.com/codex/tasks/task_e_68bbc5afa2e4832ca3c15fca387bd045