### PR TITLE
feat(editor): add slug input with validation

### DIFF
--- a/app/api/check-slug/route.ts
+++ b/app/api/check-slug/route.ts
@@ -1,0 +1,11 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+// Placeholder: in a real app, check against database.
+const usedSlugs = new Set(['example-post']);
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const slug = searchParams.get('slug') || '';
+  const unique = slug ? !usedSlugs.has(slug) : false;
+  return NextResponse.json({ unique });
+}

--- a/src/components/editor/TitleInput.tsx
+++ b/src/components/editor/TitleInput.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { useState } from 'react';
 import { useAppDispatch, useAppSelector } from '@/src/store/hooks';
 import { setTitle, setSlug } from '@/src/store/slices/editorSlice';
 
@@ -15,6 +16,23 @@ function slugify(input: string) {
 export default function TitleInput() {
   const dispatch = useAppDispatch();
   const { title, slug } = useAppSelector((s) => s.editor);
+  const [slugError, setSlugError] = useState<string | null>(null);
+  const [slugEdited, setSlugEdited] = useState(false);
+
+  async function checkSlugUnique(s: string) {
+    if (!s) {
+      setSlugError('הסלאג לא יכול להיות ריק');
+      return;
+    }
+    try {
+      const res = await fetch(`/api/check-slug?slug=${encodeURIComponent(s)}`);
+      const data = await res.json();
+      if (!data.unique) setSlugError('הסלאג כבר קיים');
+      else setSlugError(null);
+    } catch {
+      setSlugError('שגיאה בבדיקת הסלאג');
+    }
+  }
 
   return (
     <div style={{ marginBottom: 12 }}>
@@ -23,15 +41,35 @@ export default function TitleInput() {
         onChange={(e) => {
           const v = e.target.value;
           dispatch(setTitle(v));
-          if (!slug) dispatch(setSlug(slugify(v)));
+          if (!slug && !slugEdited) {
+            const newSlug = slugify(v);
+            dispatch(setSlug(newSlug));
+            checkSlugUnique(newSlug);
+          }
         }}
         placeholder="כותרת הפוסט"
         aria-label="כותרת הפוסט"
         style={{ width: '100%', padding: 8, fontSize: 24 }}
       />
-      <div className="muted" style={{ marginTop: 6 }}>
-        סלאג: <code>{slug || '(ייווצר אוטומטית מהכותרת)'}</code>
-      </div>
+      <input
+        value={slug}
+        onChange={(e) => {
+          setSlugEdited(true);
+          const v = slugify(e.target.value);
+          dispatch(setSlug(v));
+          if (!v) setSlugError('הסלאג לא יכול להיות ריק');
+          else setSlugError(null);
+        }}
+        onBlur={() => checkSlugUnique(slug)}
+        placeholder="סלאג"
+        aria-label="סלאג"
+        style={{ width: '100%', padding: 8, fontSize: 18, marginTop: 8 }}
+      />
+      {slugError && (
+        <div className="muted" style={{ color: 'red', marginTop: 6 }}>
+          {slugError}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add slug input below title with uniqueness & emptiness validation
- create API endpoint to check slug availability

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: ESLint couldn't find a configuration file)

------
https://chatgpt.com/codex/tasks/task_e_68bbc5a923c0832cb65742c2a57938cd